### PR TITLE
Move sticky header out of the way so foreground touches work

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -362,10 +362,17 @@ class ParallaxScrollView extends Component {
 	}) {
 		const { viewWidth } = this.state
 		const { scrollY } = this
+
+		const translateY = interpolate(scrollY, {
+			inputRange: [0, stickyHeaderHeight],
+			outputRange: [-stickyHeaderHeight, 0],
+			extrapolate: 'clamp'
+		})
+
 		if (renderStickyHeader || renderFixedHeader) {
 			const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight)
 			return (
-				<View
+				<Animated.View
 					style={[
 						styles.stickyHeader,
 						{
@@ -385,7 +392,7 @@ class ParallaxScrollView extends Component {
                 //   extrapolate: 'clamp',
                 // }),
                 opacity: interpolate(scrollY, {
-                  inputRange: [0, p],
+                  inputRange: [stickyHeaderHeight, p],
                   outputRange: [0, 1],
                   extrapolate: 'clamp',
                 }),
@@ -413,7 +420,7 @@ class ParallaxScrollView extends Component {
           : null
           }
 					{renderFixedHeader && renderFixedHeader()}
-				</View>
+				</Animated.View>
 			)
 		} else {
 			return null


### PR DESCRIPTION
https://github.com/i6mi6/react-native-parallax-scroll-view/pull/112/files